### PR TITLE
Add a Privacy statement to pride.codes site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -30,6 +30,10 @@ googleAnalytics = "UA-106326008-1"
   name = "About"
   url = "about/"
 
+  [[params.navlinks]]
+  name = "Privacy statement"
+  url = "privacy-statement"
+
   # [[params.navlinks]]
   # name = "Get in touch"
   # url = "contact/"

--- a/content/privacy-statement.md
+++ b/content/privacy-statement.md
@@ -1,0 +1,52 @@
++++
+slug="privacy-statement"
+url="privacy-statement"
++++
+
+# Privacy Statement
+Thank you for visiting pride.codes, an online and open source service hosted by Jack Skinner (https://developerjack.com), Sydney, NSW. As a free and open source project we respect and protect the privacy of our users. This privacy statement explains how we collect, store, and use information.
+
+The term "Personal Information" in this privacy policy means any information from which your identity is apparent or can be reasonably ascertained.
+
+We do not collect Personal Information about you when you visit this online service.
+You can use this service without telling us who you are or revealing other Personal Information.
+
+### The short summary
+
+> In summary, pride.codes does not track, store or request your personal or sensitive information. We use industry standard and well known anonymous usage analytics and access logs to understand how you use pride.codes so that we can improve it. By flying a pride.codes flag on your website you understand that you are sharing sensitive information such as your political opinion.
+
+### Where does this privacy statement apply?
+Pride.codes provides complimentary web hosting for styles, scripts and images free of charge. As such we serve content to a global list of websites both inside and outside Australia.
+
+### Your Personal information
+If you contact us we will collect the email address you nominate and any other identifying information you provide, such as a name or phone number. If you reach out to us by social media we may collect your publicly shared information such as Twitter handle or profile URL.
+
+Please do not send us other personal or sensitive information.
+
+In the event of unlawful activity or serious threats to health and safety we may share your Personal Information with appropriate organisations as we see fit and necessary.
+
+In all other circumstances we will not share any Personal Information you have shared with us.
+
+Naturally you can opt out of further contact from us at any time.
+
+### How we deal with complaints and requests
+If you have concerns about how your Personal Information is collected, stored or used, you may contact us by email. You may request access to the Personal Information about you that we have and you may ask us to correct your Personal information as appropriate.
+To protect your privacy and the privacy of others we may need evidence of your identity; for example requesting us to update an email address via social media may not be appropriate.
+
+### Website analytics
+To help us improve pride.codes and to improve your experience on our site we may use cookies. These are an industry standard technology and most websites use them. They involve storing a small amount of data on your computer as a tool to remember your preferences. You can refuse to use cookies by configuring your web browser however doing so may mean you’re not able to use the full functionality on this website.
+
+We may include links to other websites outside pride.codes; please be conscious that we are not responsible for the content or privacy practices on these sites.
+
+pride.codes uses Google Analytics to provide us with reports to understand the website traffic and usage. Google Analytics will transmit usage data to the United States and globally but will not identify a specific individual. You should read [Google's Privacy Policy](http://www.google.com/policies/privacy/) and you can opt out of Google Analytics by disabling JavaScript, refusing/disabling cookies, or by using the [opt-out service provided by Google](https://tools.google.com/dlpage/gaoptout).
+
+pride.codes content (https://cdn.pride.codes/) is is hosted on Amazon Web Services (aws.amazon.com) and distributed using a global content delivery network. The pride.codes homepage is hosted using Netlify (netlify.com) using a global content delivery network. We may use service logs from our hosting providers and content delivery networks to improve pride.codes including referral and request data. Where the option is available, we prefer storage and compute services provided in Australia.
+
+### Our objectives
+We appreciate you value your privacy, and so do we. pride.codes does not attempt to in any conscious form, track or store Personal Information about any users of the site.
+
+### Applicable law
+This online service is bound by the provisions of the [Privacy Act 1988 (Cth)](https://www.legislation.gov.au/Series/C2004A037122), including the [Australian Privacy Principles](https://www.oaic.gov.au/privacy-law/privacy-act/australian-privacy-principles). pride.codes does not request, or store any information such as your political opinion, sexual orientation or other sensitive information as set out in the Australian Privacy Principles.
+
+### Sensitive Information
+Pride.codes does not request or store sensitive information such as that set out in the Australian Privacy Principles. By using a pride.codes asset on your website, product, or application you are sharing your support for LGBTQI+ people. In doing so, your political opinion, sexuality and other sensitive information may be inferred, assumed or shared publicly.


### PR DESCRIPTION
Added a privacy statement that:
 - Draws reference to the Australian Privacy Act
 - Draws reference to the Australian Privacy Principles
 - Highlights that users flying a pride.codes banner are consciously sharing information that may allow people to infer/assume/guess sensitive information such as political opinion (that's kinda the point)
 - Provides transparency for where we host and serve our content from
 - Provides transparency for how we track and analyse usage data.